### PR TITLE
Fix typo and whitespace in templates

### DIFF
--- a/templates/channels.html
+++ b/templates/channels.html
@@ -14,7 +14,7 @@
           <h4 class="ui header">Peer Count
             <div class="sub header">{{ stats.peer_count|format_thousands_int }} peers</div>
           </h4>
-		      <div class="ui clearing divider"></div>
+            <div class="ui clearing divider"></div>
           <h4 class="ui header">Channel Count
             <div class="sub header">{{ stats.channel_count|format_thousands_int }} channels</div>
           </h4>

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,7 @@
         </div>
         <div class="five wide column"></div>
         <div class="five wide right aligned column">
-          <h1 class="ui header">Connnect</h4>
+          <h1 class="ui header">Connect</h4>
           <img src="{{ qrcode(uris[0], box_size=8) }}"></img>
         </div>
       </div>


### PR DESCRIPTION
This commit fixes one typo (Connnect) and one whitespace issue (tabs instead of spaces)