### PR TITLE
Catch exception in case of "edge not found"

### DIFF
--- a/main.py
+++ b/main.py
@@ -126,7 +126,10 @@ def channels():
         peer_filter = filter(lambda x: x['pub_key'] == channel.remote_pubkey, peers)
         index = peers.index(peer_filter[0])
 
-        chan_info = stub.GetChanInfo(ln.ChanInfoRequest(chan_id=channel.chan_id))
+         try:
+            chan_info = stub.GetChanInfo(ln.ChanInfoRequest(chan_id=channel.chan_id))
+        except grpc.RpcError as e:
+            e.details()
 
         if chan_info.node1_pub == channel.remote_pubkey:
             remote_policy = {


### PR DESCRIPTION
With this change, the frontend will not break. At the moment the exception it's not handled, since it's ok to keep going.
